### PR TITLE
Format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -624,6 +624,11 @@ spec:
       workspaces:
         - name: workspace
           workspace: workspace-amd64
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
         - name: image-digest


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263