### PR TITLE
Add renovate config file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "schedule": [
+    "after 5pm on sunday"
+  ]
+}


### PR DESCRIPTION
My goal here is to throttle the rebuild cycle.

When oras-container updates, then build-definitions gets a PR to update.

When build-definitions updates, then oras gets a PR to update task refs.

If we merge quickly, this never ends. The goal here is just to slow it down.