### PR TITLE
Add attach helper script

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -3,43 +3,357 @@ kind: Pipeline
 metadata:
   name: build-pipeline
 spec:
-  finally:
-    - name: show-sbom
+    tasks:
+    - name: init
       params:
-        - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
+      - name: image-url
+        value: $(params.output-image)
+      - name: rebuild
+        value: $(params.rebuild)
+      - name: skip-checks
+        value: $(params.skip-checks)
       taskRef:
         params:
-          - name: name
-            value: show-sbom
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-show-sbom:0.1@sha256:1580a8766406207d3a7500cc0c62f8ec4cd935d772008a74dd71ec7e94af2f45
-          - name: kind
-            value: task
+        - name: name
+          value: init
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:0523b51c28375a3f222da91690e22eff11888ebc98a0c73c468af44762265c69
+        - name: kind
+          value: task
         resolver: bundles
-    - name: show-summary
+    - name: clone-repository
       params:
-        - name: pipelinerun-name
-          value: $(context.pipelineRun.name)
-        - name: git-url
-          value: $(tasks.clone-repository-amd64.results.url)?rev=$(tasks.clone-repository-amd64.results.commit)
-        - name: image-url
-          value: $(params.output-image)
-        - name: build-task-status
-          value: $(tasks.build-container.status)
+      - name: url
+        value: $(params.git-url)
+      - name: revision
+        value: $(params.revision)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - init
       taskRef:
         params:
-          - name: name
-            value: summary
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-summary:0.2@sha256:f469381ae442a477aaddbbef5a02fc0eec1ff6dfb3b9e2df0bfb2d614f78b348
-          - name: kind
-            value: task
+        - name: name
+          value: git-clone-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:4bf48d038ff12d25bdeb5ab3e98dc2271818056f454c83d7393ebbd413028147
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      workspaces:
+      - name: basic-auth
+        workspace: git-auth
+    - name: prefetch-dependencies
+      params:
+      - name: input
+        value: $(params.prefetch-input)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).prefetch
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      runAfter:
+      - clone-repository
+      taskRef:
+        params:
+        - name: name
+          value: prefetch-dependencies-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:30c903144e8c8d8c65fb6ec40dd3ff737091609f96fa9f326c047f71242dade4
+        - name: kind
+          value: task
         resolver: bundles
       workspaces:
-        - name: workspace
-          workspace: workspace
-  params:
+      - name: git-basic-auth
+        workspace: git-auth
+      - name: netrc
+        workspace: netrc
+    - matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
+      name: build-images
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: HERMETIC
+        value: $(params.hermetic)
+      - name: PREFETCH_INPUT
+        value: $(params.prefetch-input)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: BUILD_ARGS
+        value:
+        - $(params.build-args[*])
+      - name: BUILD_ARGS_FILE
+        value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
+      runAfter:
+      - prefetch-dependencies
+      taskRef:
+        params:
+        - name: name
+          value: buildah-remote-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:d582f95f21735f44947c62c2976972dc062cba20e6a3694990bafd5827665bb7
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-image-index
+      params:
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: COMMIT_SHA
+        value: $(tasks.clone-repository.results.commit)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: ALWAYS_BUILD_INDEX
+        value: $(params.build-image-index)
+      - name: IMAGES
+        value:
+        - $(tasks.build-images.results.IMAGE_REF[*])
+      runAfter:
+      - build-images
+      taskRef:
+        params:
+        - name: name
+          value: build-image-index
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:ebc17bb22481160eec6eb7277df1e48b90f599bebe563cd4f046807f4e32ced3
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+    - name: build-source-image
+      params:
+      - name: BINARY_IMAGE
+        value: $(params.output-image)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: source-build-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:bd786bc1d33391bb169f98a1070d1a39e410b835f05fd0db0263754c65bd9bea
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(tasks.init.results.build)
+        operator: in
+        values:
+        - "true"
+      - input: $(params.build-source-image)
+        operator: in
+        values:
+        - "true"
+    - name: deprecated-base-image-check
+      params:
+      - name: IMAGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: deprecated-image-check
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:5a1a165fa02270f0a947d8a2131ee9d8be0b8e9d34123828c2bef589e504ee84
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clair-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clair-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:0a5421111e7092740398691d5bd7c125cc0896f29531d19414bb5724ae41692a
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: ecosystem-cert-preflight-checks
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:df8a25a3431a70544172ed4844f9d0c6229d39130633960729f825a031a7dea9
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: sast-snyk-check
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: sast-snyk-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:65a213322ea7c64159e37071d369d74b6378b23403150e29537865cada90f022
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: clamav-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: clamav-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b4f450f1447b166da671f1d5819ab5a1485083e5c27ab91f7d8b7a2ff994c8c2
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
+    - name: apply-tags
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: apply-tags
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:87fd7fc0e937aad1a8db9b6e377d7e444f53394dafde512d68adbea6966a4702
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: push-dockerfile
+      params:
+      - name: IMAGE
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: push-dockerfile-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:80d48a1b9d2707490309941ec9f79338533938f959ca9a207b481b0e8a5e7a93
+        - name: kind
+          value: task
+        resolver: bundles
+    - name: rpms-signature-scan
+      params:
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: rpms-signature-scan
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+    params:
     - description: Source Repository URL
       name: git-url
       type: string
@@ -51,11 +365,13 @@ spec:
       name: output-image
       type: string
     - default: .
-      description: Path to the source code of an application's component from where to build image.
+      description: Path to the source code of an application's component from where
+        to build image.
       name: path-context
       type: string
     - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter path-context
+      description: Path to the Dockerfile inside the context specified by parameter
+        path-context
       name: dockerfile
       type: string
     - default: "false"
@@ -74,641 +390,61 @@ spec:
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string
-    - default: "false"
-      description: Java build
-      name: java
-      type: string
     - default: ""
-      description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+      description: Image tag expiration time, time values could be something like
+        1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
     - default: "false"
       description: Build a source image.
       name: build-source-image
       type: string
+    - default: "true"
+      description: Add built image into an OCI image index
+      name: build-image-index
+      type: string
+    - default: []
+      description: Array of --build-arg values ("arg=value" strings) for buildah
+      name: build-args
+      type: array
     - default: ""
-      description: Path to a file with build arguments which will be passed to podman during build
+      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
       type: string
-  results:
-    - description: ""
-      name: IMAGE_URL
-      value: $(tasks.build-container.results.IMAGE_URL)
-    - description: ""
-      name: IMAGE_DIGEST
-      value: $(tasks.build-container.results.IMAGE_DIGEST)
-    - description: ""
-      name: CHAINS-GIT_URL
-      value: $(tasks.clone-repository-amd64.results.url)
-    - description: ""
-      name: CHAINS-GIT_COMMIT
-      value: $(tasks.clone-repository-amd64.results.commit)
-  tasks:
-    - name: init
-      params:
-        - name: image-url
-          value: $(params.output-image)
-        - name: rebuild
-          value: $(params.rebuild)
-        - name: skip-checks
-          value: $(params.skip-checks)
-      taskRef:
-        params:
-          - name: name
-            value: init
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-init:0.2@sha256:07b8eb6a9533525a397c296246d3eb6ec4771b520a1bfee817ce2b7ede25c43d
-          - name: kind
-            value: task
-        resolver: bundles
-    - name: clone-repository-amd64
-      params:
-        - name: url
-          value: $(params.git-url)
-        - name: revision
-          value: $(params.revision)
-      runAfter:
-        - init
-      taskRef:
-        params:
-          - name: name
-            value: git-clone
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a3e22f57fbf8398fbe93fbeeb38e03756cd073182d6d109fe8e8cde57b561603
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: output
-          workspace: workspace-amd64
-        - name: basic-auth
-          workspace: git-auth
-    - name: prefetch-dependencies-amd64
-      params:
-        - name: input
-          value: $(params.prefetch-input)
-      runAfter:
-        - clone-repository-amd64
-      taskRef:
-        params:
-          - name: name
-            value: prefetch-dependencies
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:e2139770f64729d8f282d23fbdd38b17dc3e4da6074d1f55e4b03340b5eaccff
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.prefetch-input)
-          operator: notin
-          values:
-            - ""
-      workspaces:
-        - name: source
-          workspace: workspace-amd64
-        - name: git-basic-auth
-          workspace: git-auth
-    - name: build-container-amd64
-      params:
-        - name: IMAGE
-          value: $(params.output-image)-amd64
-        - name: DOCKERFILE
-          value: $(params.dockerfile)
-        - name: CONTEXT
-          value: $(params.path-context)
-        - name: HERMETIC
-          value: $(params.hermetic)
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.image-expires-after)
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository-amd64.results.commit)
-        - name: BUILD_ARGS_FILE
-          value: $(params.build-args-file)
-      runAfter:
-        - prefetch-dependencies-amd64
-      taskRef:
-        params:
-          - name: name
-            value: buildah
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.2@sha256:712b3eee4f73ac0bfc0fe2008190a649418caa6741ef77f4bc8eec2aedc0286b
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: source
-          workspace: workspace-amd64
-    - name: clone-repository-arm64
-      params:
-        - name: url
-          value: $(params.git-url)
-        - name: revision
-          value: $(params.revision)
-      runAfter:
-        - init
-      taskRef:
-        params:
-          - name: name
-            value: git-clone
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a3e22f57fbf8398fbe93fbeeb38e03756cd073182d6d109fe8e8cde57b561603
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: output
-          workspace: workspace-arm64
-        - name: basic-auth
-          workspace: git-auth
-    - name: prefetch-dependencies-arm64
-      params:
-        - name: input
-          value: $(params.prefetch-input)
-      runAfter:
-        - clone-repository-arm64
-      taskRef:
-        params:
-          - name: name
-            value: prefetch-dependencies
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:e2139770f64729d8f282d23fbdd38b17dc3e4da6074d1f55e4b03340b5eaccff
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.prefetch-input)
-          operator: notin
-          values:
-            - ""
-      workspaces:
-        - name: source
-          workspace: workspace-arm64
-        - name: git-basic-auth
-          workspace: git-auth
-    - name: build-container-arm64
-      params:
-        - name: IMAGE
-          value: $(params.output-image)-arm64
-        - name: DOCKERFILE
-          value: $(params.dockerfile)
-        - name: CONTEXT
-          value: $(params.path-context)
-        - name: HERMETIC
-          value: $(params.hermetic)
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.image-expires-after)
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository-arm64.results.commit)
-        - name: BUILD_ARGS_FILE
-          value: $(params.build-args-file)
-        - name: PLATFORM
-          value: linux/arm64
-      runAfter:
-        - prefetch-dependencies-arm64
-      taskRef:
-        params:
-          - name: name
-            value: buildah-remote
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:6b9a693a1fbec04b8ac75025aaf818bf9fccc6de5a54c3051b389c7e44cc0833
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: source
-          workspace: workspace-arm64
-    - name: clone-repository-ppc64le
-      params:
-        - name: url
-          value: $(params.git-url)
-        - name: revision
-          value: $(params.revision)
-      runAfter:
-        - init
-      taskRef:
-        params:
-          - name: name
-            value: git-clone
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a3e22f57fbf8398fbe93fbeeb38e03756cd073182d6d109fe8e8cde57b561603
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: output
-          workspace: workspace-ppc64le
-        - name: basic-auth
-          workspace: git-auth
-    - name: prefetch-dependencies-ppc64le
-      params:
-        - name: input
-          value: $(params.prefetch-input)
-      runAfter:
-        - clone-repository-ppc64le
-      taskRef:
-        params:
-          - name: name
-            value: prefetch-dependencies
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:e2139770f64729d8f282d23fbdd38b17dc3e4da6074d1f55e4b03340b5eaccff
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.prefetch-input)
-          operator: notin
-          values:
-            - ""
-      workspaces:
-        - name: source
-          workspace: workspace-ppc64le
-        - name: git-basic-auth
-          workspace: git-auth
-    - name: build-container-ppc64le
-      params:
-        - name: IMAGE
-          value: $(params.output-image)-ppc64le
-        - name: DOCKERFILE
-          value: $(params.dockerfile)
-        - name: CONTEXT
-          value: $(params.path-context)
-        - name: HERMETIC
-          value: $(params.hermetic)
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.image-expires-after)
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository-ppc64le.results.commit)
-        - name: BUILD_ARGS_FILE
-          value: $(params.build-args-file)
-        - name: PLATFORM
-          value: linux/ppc64le
-      runAfter:
-        - prefetch-dependencies-ppc64le
-      taskRef:
-        params:
-          - name: name
-            value: buildah-remote
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:6b9a693a1fbec04b8ac75025aaf818bf9fccc6de5a54c3051b389c7e44cc0833
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: source
-          workspace: workspace-ppc64le
-    - name: clone-repository-s390x
-      params:
-        - name: url
-          value: $(params.git-url)
-        - name: revision
-          value: $(params.revision)
-      runAfter:
-        - init
-      taskRef:
-        params:
-          - name: name
-            value: git-clone
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a3e22f57fbf8398fbe93fbeeb38e03756cd073182d6d109fe8e8cde57b561603
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: output
-          workspace: workspace-s390x
-        - name: basic-auth
-          workspace: git-auth
-    - name: prefetch-dependencies-s390x
-      params:
-        - name: input
-          value: $(params.prefetch-input)
-      runAfter:
-        - clone-repository-s390x
-      taskRef:
-        params:
-          - name: name
-            value: prefetch-dependencies
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-prefetch-dependencies:0.1@sha256:e2139770f64729d8f282d23fbdd38b17dc3e4da6074d1f55e4b03340b5eaccff
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.prefetch-input)
-          operator: notin
-          values:
-            - ""
-      workspaces:
-        - name: source
-          workspace: workspace-s390x
-        - name: git-basic-auth
-          workspace: git-auth
-    - name: build-container-s390x
-      params:
-        - name: IMAGE
-          value: $(params.output-image)-s390x
-        - name: DOCKERFILE
-          value: $(params.dockerfile)
-        - name: CONTEXT
-          value: $(params.path-context)
-        - name: HERMETIC
-          value: $(params.hermetic)
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.image-expires-after)
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository-s390x.results.commit)
-        - name: BUILD_ARGS_FILE
-          value: $(params.build-args-file)
-        - name: PLATFORM
-          value: linux/s390x
-      runAfter:
-        - prefetch-dependencies-s390x
-      taskRef:
-        params:
-          - name: name
-            value: buildah-remote
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:6b9a693a1fbec04b8ac75025aaf818bf9fccc6de5a54c3051b389c7e44cc0833
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: source
-          workspace: workspace-s390x
-    - name: build-container
-      params:
-        - name: IMAGE
-          value: $(params.output-image)
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository-amd64.results.commit)
-        - name: IMAGES
-          value:
-            - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
-            - $(tasks.build-container-s390x.results.IMAGE_URL)@$(tasks.build-container-s390x.results.IMAGE_DIGEST)
-            - $(tasks.build-container-ppc64le.results.IMAGE_URL)@$(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
-      runAfter:
-        - build-container-amd64
-        - build-container-arm64
-        - build-container-s390x
-        - build-container-ppc64le
-      taskRef:
-        params:
-          - name: name
-            value: build-image-manifest
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-build-image-manifest:0.1@sha256:90f4d93913d03fc37cb147551bf81d9a367796b43e3b16e173e6d3befa0c9c7a
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-    - name: build-source-image
-      params:
-        - name: BINARY_IMAGE
-          value: $(params.output-image)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: source-build
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-source-build:0.1@sha256:1a55db5a25fd9ef0c25a7d5af793ec192b9ba93fe8debd0f986116b9563f654e
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(tasks.init.results.build)
-          operator: in
-          values:
-            - "true"
-        - input: $(params.build-source-image)
-          operator: in
-          values:
-            - "true"
-      workspaces:
-        - name: workspace
-          workspace: workspace-amd64
-    - name: deprecated-base-image-check
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: deprecated-image-check
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.4@sha256:566ae0df80f8447558595a996627bf0b5482dc0eaa9fbc33b8154587aed51a05
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-    - name: clair-scan
-      params:
-        - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: clair-scan
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-clair-scan:0.2@sha256:45d1c904ee61c6c227011b0d70f5c7c8786376d2d06f4f8c9acc5e706c4b9b4c
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: ecosystem-cert-preflight-checks
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:262344797a3c61b597b75d970c06a434c71fb3a827a55d1e569ea1e1a2b9150b
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-    - name: sast-snyk-check
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: sast-snyk-check
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.3@sha256:91df1d44c742af695ce1cd93c604b040c50d43d137f55385572fd5140f9749ab
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-      workspaces:
-        - name: workspace
-          workspace: workspace-amd64
-      params:
-        - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
-    - name: clamav-scan
-      params:
-        - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: clamav-scan
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:a9521f8ba018bd18a1271ce44da48762c9df3d6693bcdfd704de90481a660d6c
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-    - name: sbom-json-check
-      params:
-        - name: IMAGE_URL
-          value: $(tasks.build-container.results.IMAGE_URL)
-        - name: IMAGE_DIGEST
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: sbom-json-check
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-sbom-json-check:0.2@sha256:a8f1748144a51dbb90d140ae788a95e05d65dcdd0625efceedce2f5ae755c654
-          - name: kind
-            value: task
-        resolver: bundles
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-    - name: apply-tags
-      params:
-        - name: IMAGE
-          value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-        - build-container
-      taskRef:
-        params:
-          - name: name
-            value: apply-tags
-          - name: bundle
-            value: quay.io/redhat-appstudio-tekton-catalog/task-apply-tags:0.1@sha256:362e24943d5db3e6001b079f081b575784e8f88bc6c5b64998038b55311a3306
-          - name: kind
-            value: task
-        resolver: bundles
-    - name: rpms-signature-scan
-      params:
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: fail-unsigned
-        value: true
-      taskRef:
-        params:
-          - name: name
-            value: rpms-signature-scan
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
-          - name: kind
-            value: task
-        resolver: bundles
-  workspaces:
-    - name: workspace-amd64
-    - name: workspace-arm64
-    - name: workspace-ppc64le
-    - name: workspace-s390x
+    - default:
+      - linux/x86_64
+      description: List of platforms to build the container images on. The available
+        set of values is determined by the configuration of the multi-platform-controller.
+      name: build-platforms
+      type: array
+    workspaces:
     - name: git-auth
       optional: true
+    - name: netrc
+      optional: true
+    results:
+    - description: ""
+      name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - description: ""
+      name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - description: ""
+      name: CHAINS-GIT_URL
+      value: $(tasks.clone-repository.results.url)
+    - description: ""
+      name: CHAINS-GIT_COMMIT
+      value: $(tasks.clone-repository.results.commit)
+    # finally:
+    # - name: show-sbom
+    #   params:
+    #   - name: IMAGE_URL
+    #     value: $(tasks.build-image-index.results.IMAGE_URL)
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: show-sbom
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:945a7c9066d3e0a95d3fddb7e8a6992e4d632a2a75d8f3a9bd2ff2fef0ec9aa0
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles

--- a/.tekton/oras-container-pull-request.yaml
+++ b/.tekton/oras-container-pull-request.yaml
@@ -30,41 +30,15 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-platforms
+    value:
+      - localhost
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   pipelineRef:
     name: build-pipeline
   workspaces:
-    - name: workspace-amd64
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-arm64
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-ppc64le
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-s390x
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: git-auth
-      secret:
-        secretName: '{{ git_auth_secret }}'
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/oras-container-push.yaml
+++ b/.tekton/oras-container-push.yaml
@@ -27,41 +27,15 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  - name: build-platforms
+    value:
+      - localhost
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
   pipelineRef:
     name: build-pipeline
   workspaces:
-    - name: workspace-amd64
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-arm64
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-ppc64le
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: workspace-s390x
-      volumeClaimTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-    - name: git-auth
-      secret:
-        secretName: '{{ git_auth_secret }}'
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'

--- a/.tekton/test.yaml
+++ b/.tekton/test.yaml
@@ -24,6 +24,8 @@ spec:
               oc image extract --confirm quay.io/konflux-ci/yq:latest --path=/usr/bin/yq:/usr/bin/. && chmod +x /usr/bin/yq
 
               echo -e "Testing Snapshot:\n ${SNAPSHOT}"
+              TESTS_FAILED="false"
+              failure_num=0
 
               IMAGE=$(echo ${SNAPSHOT} | yq -r '.components[].containerImage')
               echo -e "Found image ${IMAGE}"
@@ -33,6 +35,8 @@ spec:
               oc image extract --confirm ${IMAGE} --path=/usr/bin/yq:/usr/bin/. && chmod +x /usr/bin/yq
               oc image extract --confirm ${IMAGE} --path=/usr/local/bin/retry:/usr/local/bin/. && chmod +x /usr/local/bin/retry
               oc image extract --confirm ${IMAGE} --path=/usr/local/bin/select-oci-auth:/usr/local/bin/. && chmod +x /usr/local/bin/select-oci-auth
+              oc image extract --confirm ${IMAGE} --path=/usr/local/bin/attach-helper:/usr/local/bin/. && chmod +x /usr/local/bin/attach-helper
+              oc image extract --confirm ${IMAGE} --path=/usr/local/bin/oras-options:/usr/local/bin/. && chmod +x /usr/local/bin/oras-options
 
               REPO=$(echo ${IMAGE} | awk -F '@' '{ print $1 }')
               TAG="$(echo ${IMAGE} | awk -F '@' '{print $2 }' | sed s/:/-/).test"
@@ -40,21 +44,178 @@ spec:
               echo "Extracting relevant OCI auth for $REPO"
               select-oci-auth $REPO > auth.json
 
+              # Test pushing directly with oras
               echo "Pushing foo.txt to $REPO:$TAG"
               echo -n "hello world" > foo.txt
               oras push --no-tty --registry-config auth.json $REPO:$TAG foo.txt:text/plain
 
-              rm foo.txt
+              mv foo.txt check.txt
 
+              # Test pulling directly with oras, ensuring that the file content is unchanged
               echo "Pulling foo.txt to $REPO:$TAG"
               oras pull --no-tty --registry-config auth.json $REPO:$TAG
               OUTPUT=$(cat foo.txt)
 
-              echo "Expecting hello world"
-              echo "Received ${OUTPUT}"
-
-              if [ "$OUTPUT" == "hello world" ]; then
-                exit 0
+              diff foo.txt check.txt > diff.txt
+              if [ $? -eq 0 ]; then
+                echo "Recieved the expected output"
               else
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+                echo "ERROR: Expecting hello world"
+                echo "Received ${OUTPUT}"
+              fi
+
+              # Test attaching simple files
+              attach-helper --subject $REPO:$TAG foo.txt,foo-digest.txt
+              attach-helper --subject $REPO:$TAG --artifact-type "application/vnd.konflux-ci.test-artifact" --media-type-name "foobar" check.txt
+
+              ## Ensure that the files are unmodified and that the digest is set properly
+              diff foo.txt check.txt > diff.txt
+              if [ ! $? -eq 0 ]; then
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+                echo "ERROR: Files were modified when attaching."
+              fi
+              sha256sum_verify="$(sha256sum "foo.txt")"
+              digest_verify="${sha256sum_verify/ */}"
+              digest_result=$(cat foo-digest.txt)
+              if [[ "oci:${REPO}@sha256:${digest_verify}" == "$digest_result" ]]; then
+                echo "Digest properly created"
+              else
+                echo "ERROR: Reported doesn't match oci:${REPO}@sha256:${digest_verify}"
+                cat foo-digest.txt
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
+              ## Check to make sure that all attachments have happened properly. Looking at both the total number
+              ## and the number for each artifact type (one custom, one default)
+              mkdir discoveries
+              oras discover -v --format tree $REPO:$TAG | tee discoveries/all_attached
+              oras discover -v --format tree --artifact-type "application/vnd.konflux-ci.attached-artifact" $REPO:$TAG > discoveries/default_attached
+              oras discover -v --format tree --artifact-type "application/vnd.konflux-ci.test-artifact" $REPO:$TAG > discoveries/custom_attached
+
+              if [[ "$(cat discoveries/all_attached | wc -l)" == "7" ]]; then
+                echo "Two artifacts attached"
+              else
+                echo "ERROR: All attached artifacts not found"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+              if [[ "$(cat discoveries/default_attached | wc -l)" == "4" ]]; then
+                echo "One artifact attached with type application/vnd.konflux-ci.attached-artifact"
+              else
+                echo "ERROR: Artifact attachment application/vnd.konflux-ci.attached-artifact not found"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+              if [[ "$(cat discoveries/custom_attached | wc -l)" == "4" ]]; then
+                echo "One artifact attached with type application/vnd.konflux-ci.test-artifact"
+              else
+                echo "ERROR: Artifact attachment application/vnd.konflux-ci.test-artifact not found"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
+              ## Check to make sure that we have found each of the media types used. One is custom, another is auto.
+              oras manifest fetch --pretty $REPO:$TAG
+              referenced_artifacts=$( oras discover --format json $REPO:$TAG | yq -e '.manifests[].reference')
+              found_type1="false"
+              found_type2="false"
+              echo "Looking at mediaType for all referenced artifacts"
+              for artifact in ${referenced_artifacts[@]}; do
+                oras manifest fetch --pretty $artifact
+                mediaType=$(oras manifest fetch --pretty $artifact | yq -e '.layers[].mediaType')
+                if [[ "$mediaType" == "application/vnd.konflux-ci.attached-artifact.foo+txt" ]]; then
+                  found_type1="true"
+                fi
+                if [[ "$mediaType" == "application/vnd.konflux-ci.test-artifact.foobar" ]]; then
+                  found_type2="true"
+                fi
+              done
+              if [[ "$found_type1" == "true" ]]; then
+                echo "Found one application/vnd.konflux-ci.attached-artifact.foo+txt mediaType"
+              else
+                echo "ERROR: Didn't find application/vnd.konflux-ci.attached-artifact.foo+txt mediaType"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+              if [[ "$found_type2" == "true" ]]; then
+                echo "Found one application/vnd.konflux-ci.test-artifact.foobar mediaType"
+              else
+                echo "ERROR: Didn't find application/vnd.konflux-ci.test-artifact.foobar mediaType"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
+              # Test attaching directories
+              attach-helper --subject $REPO:$TAG --artifact-type "application/vnd.konflux-ci.test-directory" discoveries,discoveries-digest.txt
+
+              ## Ensure that the the artifact (custom) and media (auto) types are as expected for directories
+              oci_path=$(cat discoveries-digest.txt)
+              oras discover --format json --artifact-type "application/vnd.konflux-ci.test-directory" $REPO:$TAG | yq -e '.manifests[].reference' > referenced_directory_artifacts
+              if [ ! "$(cat referenced_directory_artifacts | wc -l)" == "1"]; then
+                echo "ERROR: Improper number of referenced artifacts for type application/vnd.konflux-ci.test-directory"
+                cat referenced_directory_artifacts
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+              artifactType=$(oras manifest fetch --pretty $(cat referenced_directory_artifacts | head -n 1) | yq -e '.artifactType')
+              mediaType=$(oras manifest fetch --pretty $(cat referenced_directory_artifacts | head -n 1) | yq -e '.layers[].mediaType')
+              if [[ "$artifactType" == "application/vnd.konflux-ci.test-directory" ]]; then
+                echo "Directory artifactType matches"
+              else
+                echo "ERROR: Directory artifact type was ${artifactType}/nexpected: application/vnd.konflux-ci.test-directory"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+              if [[ "$mediaType" == "application/vnd.konflux-ci.test-directory.discoveries+gzip" ]]; then
+                echo "Directory mediaType matches"
+              else
+                echo "ERROR: Directory media type was ${mediaType}/nexpected: application/vnd.konflux-ci.test-directory.discoveries+gzip"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
+              ## Ensure that the blob digest matches for a directory 
+              oras_digest=$(oras manifest fetch --pretty $(cat referenced_directory_artifacts | head -n 1) | yq -e ".layers[0].digest")
+              if [ "${oras_digest}" == "$(echo -n ${oci_path} | cut -d@ -f2)" ]; then
+                echo "Directory blob digests match"
+              else
+                echo "ERROR: Directory blob digest does not match returned value"
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
+              ## Ensure that directory content matches
+              mkdir unzip
+              oras blob fetch ${oci_path#*oci:} --output - | tar -C "unzip" "-zxpf" -
+              diff unzip discoveries > dir_diff.txt
+              if [ $? -eq 0 ]; then
+                echo "Unzipped directory result"
+              else
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+                echo "ERROR: Unzipped directories do not match"
+                cat dir_diff.txt
+              fi
+
+              # Test attaching multiple files
+              echo "one" > one.txt
+              echo "two" > two.txt
+              attach-helper --subject $REPO:$TAG --artifact-type "application/vnd.konflux-ci.multiple-artifacts" one.txt two.txt
+              oras discover --format json --artifact-type "application/vnd.konflux-ci.multiple-artifacts" $REPO:$TAG | yq -e '.manifests[].reference' > referenced_multiple_artifacts
+              if [ ! "$(cat referenced_multiple_artifacts | wc -l)" == "1"]; then
+                echo "ERROR: All artifacts attached in one call not found"
+                cat referenced_multiple_artifacts
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              else
+                echo "Attaching multiple artifacts works"
+              fi
+
+              if [ "$TESTS_FAILED" == "true" ]; then
+                echo "$failure_num tests failed."
                 exit 1
               fi

--- a/Containerfile
+++ b/Containerfile
@@ -11,29 +11,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
+ARG ORASPKG=/oras
+
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.5 as builder
 ARG TARGETPLATFORM
+ARG ORASPKG
 #RUN dnf -y install git make && dnf -y clean all
-ENV ORASPKG /oras
-ADD . ${ORASPKG}
-WORKDIR ${ORASPKG}/oras
+ADD --chown=default oras ${ORASPKG}
+WORKDIR ${ORASPKG}
 RUN go mod vendor
 RUN make "build-$(echo $TARGETPLATFORM | sed s/\\/v8// | tr / -)"
-RUN mv ${ORASPKG}/oras/bin/$(echo $TARGETPLATFORM | sed s/\\/v8//)/oras /usr/bin/oras
-RUN mkdir /licenses && mv LICENSE /licenses/LICENSE
+RUN mv ${ORASPKG}/bin/$(echo $TARGETPLATFORM | sed s/\\/v8//)/oras ${ORASPKG}/bin/oras
 
 FROM quay.io/konflux-ci/yq:latest@sha256:4ce1f9431020387eb6c33a28a46e079b0c28b97f916243d150e70a09e41ce6b4 as yq
 
 FROM registry.access.redhat.com/ubi9:latest@sha256:2bae9062eddbbc18e76555972e7026ffe02cef560a0076e6d7f72bed2c05723f
+ARG ORASPKG
 RUN mkdir /licenses
 RUN useradd -r  --uid=65532 --create-home --shell /bin/bash oras
 
 COPY --from=yq /usr/bin/yq /usr/bin/yq
 
-COPY --from=builder /usr/bin/oras /usr/bin/oras
-COPY --from=builder /licenses/LICENSE /licenses/LICENSE
+COPY --from=builder ${ORASPKG}/bin/oras /usr/bin/oras
+COPY --from=builder ${ORASPKG}/LICENSE /licenses/LICENSE
 COPY hack/retry.sh /usr/local/bin/retry
 COPY hack/select-oci-auth.sh /usr/local/bin/select-oci-auth
+COPY hack/attach.sh /usr/local/bin/attach-helper
+COPY hack/oras-options.sh /usr/local/bin/oras-options
 
 WORKDIR /home/oras
 USER 65532:65532

--- a/hack/attach.sh
+++ b/hack/attach.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Helper function to use oras attach 
+#
+# This script can be used to easily attach artifacts. It will reduce the authication scope
+# so that oras will work when there are repository-specific tokens. It also provides a template
+# for specifying the artifactType when attaching.
+#
+# The --subject parameter is the subject to attach the artifact to, e.g.
+# registry.local/org/repo. 
+#
+# The --artifact-type (optional) parameter can be used to define an artifactType for the attached artifact.
+# If absent, "application/vnd.konflux-ci.attached-artifact" will be used.
+#
+# The --media-type-name (optional) parameter can be used to define a mediaType for the attached artifact.
+# The type will be appended to the artifact type as determined from the "--artifact-type" parameter. If 
+# absent, the filename+extension will be used.
+#
+# The --distribution-spec (optional) parameter can be used to use a specific distribution spec. Oras supports
+# the values `v1.1-referrers-api` and `v1.1-referrers-tag`. If absent the system default will be used.
+#
+# Positional parameters are artifacts that need to be attached. These are strings. Each can contain two
+# parts separated by a comma (,). The left portion defines the artifact that will be attached. The (optional)
+# right portion defines a location to store the repo and digest of the artifact after it is attached.
+# If the artifact location is a directory it will be included recursively as a gzip.
+# For example, "output.json,/home/user/out/put" means that the output.json artifact will be attached.
+# Information about this the oci blob of this artifact will be written to /home/user/out/put.
+#
+# NOTE: if a directory is passed, timestamps are not modified in the gzipped directory.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# using `-n` ensures gzip does not add a modification time to the output. This
+# helps in ensuring the archive digest is the same for the same content.
+tar_opts=(--create --use-compress-program='gzip -n' --file)
+# to debug, export the environment variable DEBUG
+if [[ -v DEBUG ]]; then
+  tar_opts=(--verbose "${tar_opts[@]}")
+  set -o xtrace
+fi
+
+# contains pairs of artifacts to attach and (optionally) paths to output the blob digest
+artifact_digest_pairs=()
+artifact_type="application/vnd.konflux-ci.attached-artifact"
+distribution_spec=""
+media_type_name=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --subject)
+        subject="$2"
+        shift
+        shift
+        ;;
+        --artifact-type)
+        artifact_type="$2"
+        shift
+        shift
+        ;;
+        --media-type-name)
+        media_type_name="$2"
+        shift
+        shift
+        ;;
+        --distribution-spec)
+        distribution_spec="$2"
+        shift
+        shift
+        ;;
+        -*)
+        echo "Unknown option $1"
+        exit 1
+        ;;
+        *)
+        artifact_digest_pairs+=("$1")
+        shift
+        ;;
+    esac
+done
+
+if [[ -z "${subject:-}" ]]; then
+    echo "--subject cannot be empty when attaching OCI artifacts"
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+
+artifacts=()
+
+# Trim off digests and tags
+repo="$(echo -n $subject | cut -d@ -f1 | cut -d: -f1)"
+
+for artifact_digest_pair in "${artifact_digest_pairs[@]}"; do
+    path="${artifact_digest_pair/,*}"
+    digest_path="${artifact_digest_pair/*,}"
+
+    artifact_name="$(basename ${path})"
+    attached_artifact="${tmp_dir}/${artifact_name}"
+    if [[ -f "${attached_artifact}" ]] || [[ -f "${attached_artifact}.gzip" ]]; then
+        echo "ERROR: artifact name collision detected. Attaching artifacts and directories with same names not supported."
+        exit 2
+    fi
+    if [ -d "${path}" ]; then
+        artifact_name="${artifact_name}.gzip"
+        attached_artifact="${attached_artifact}.gzip"
+        tar "${tar_opts[@]}" "${attached_artifact}" --directory="${path}" .
+    elif [ -f "${path}" ]; then
+        cp "${path}" "${tmp_dir}/${artifact_name}"
+    else
+        echo "ERROR: ${path} is not a valid file or directory"
+        exit 3
+    fi
+
+    sha256sum_output="$(sha256sum "${attached_artifact}")"
+    digest="${sha256sum_output/ */}"
+    echo "oci:${repo}@sha256:${digest}"
+    if [ $(echo "${artifact_digest_pair}" | grep ",") ]; then
+        echo "Saving repo and digest to ${digest_path}"
+        echo -n "oci:${repo}@sha256:${digest}" > "${digest_path}"
+    fi
+
+    artifacts+=("${artifact_name}")
+
+    echo Prepared artifact from "${path} (sha256:${digest})"
+done
+
+if [ ${#artifacts[@]} != 0 ]; then
+    # read in any oras options
+    source oras-options
+
+    # change to the artifact directory so we don't have to use absolute paths
+    pushd "${tmp_dir}" > /dev/null
+    attached_artifacts=()
+    for artifact in "${artifacts[@]}"; do
+        media_type="${artifact_type}"
+        file_name="$(basename ${artifact})"
+        if [ -n "${media_type_name}" ]; then
+            media_type="${artifact_type}.${media_type_name}"
+        else
+            file_base="${file_name%.*}"
+            file_extension="${file_name##*.}"
+            type_descriptor="${file_base}"
+            if [[ "${file_base}" != "${file_extension}" ]]; then
+                type_descriptor="${file_base}+${file_extension}"
+            fi
+            media_type="${artifact_type}.${type_descriptor}"
+        fi
+        echo "attaching artifact:"
+        echo "${file_name}:${media_type}"
+        attached_artifacts+=("${artifact}:${media_type}")
+    done
+    use_distribution_spec=()
+    if [ -n "${distribution_spec}" ]; then
+        use_distribution_spec+=("--distribution-spec ${distribution_spec}")
+    fi
+    oras attach "${oras_opts[@]}" --no-tty --registry-config <(select-oci-auth ${repo}) --artifact-type "${artifact_type}" \
+       "${use_distribution_spec[@]}" "${subject}" "${attached_artifacts[@]}"
+    popd > /dev/null
+
+    echo 'Artifacts attached'
+fi

--- a/hack/oras-options.sh
+++ b/hack/oras-options.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+oras_opts=(${ORAS_OPTIONS:-})
+
+if [[ -v CA_FILE ]]; then
+    oras_opts+=(--ca-file=${CA_FILE})
+fi
+
+if [[ -v DEBUG ]]; then
+    oras_opts+=(--debug)
+fi


### PR DESCRIPTION
In order to make oras attach operations easier, an attach script has been added with a modified interface. This includes:
* Auto-selecting the oci auth for repository-specific tokens
* Use of a common artifactType
* Saving of blob digest to a location on disk