### PR TITLE
Do not add a newline after the digest

### DIFF
--- a/.tekton/oras-container-pull-request.yaml
+++ b/.tekton/oras-container-pull-request.yaml
@@ -35,7 +35,8 @@ spec:
       - localhost
       - linux/arm64
       - linux/ppc64le
-      - linux/s390x
+      # Disabling s390x on PRs at least for now due to reliability issues
+      # - linux/s390x
   pipelineRef:
     name: build-pipeline
   workspaces:

--- a/.tekton/test.yaml
+++ b/.tekton/test.yaml
@@ -186,7 +186,7 @@ spec:
               ## Test to make sure that digest matches
               digest_pullspec=$(oras discover --format json --artifact-type "application/vnd.konflux-ci.attached-artifact" $REPO:$TAG | yq -e '.manifests[].reference')
               digestfile_content=$(cat foo-digest.txt)
-              if [ "${digest_pullspec}" == "${REPO}@sha256:${digestfile_content}" ]; then
+              if [ "${digest_pullspec}" == "${REPO}@${digestfile_content}" ]; then
                 echo "Digestfile properly created"
               else
                 echo "ERROR: Reported digest ${digestfile_content} doesn't match ${digest_pullspec}"
@@ -194,6 +194,15 @@ spec:
                 TESTS_FAILED="true"
                 failure_num=$((failure_num + 1))
               fi
+
+              ## Ensure that the digestfile doesn't have a newline
+              if ! [ "$(cat -vet foo-digest.txt)" = "$(cat foo-digest.txt)" ]; then
+                echo "ERROR: ${digestfile_content} ends in a whitespace"
+                cat foo-digest.txt
+                TESTS_FAILED="true"
+                failure_num=$((failure_num + 1))
+              fi
+
 
               # Test attaching directories
               attach-helper --subject $REPO:$TAG --artifact-type "application/vnd.konflux-ci.test-directory" --digestfile discoveries-digest.txt discoveries
@@ -227,16 +236,16 @@ spec:
 
               # Ensure that the manifest digest matches for a directory 
               directory_shasum=$(oras manifest fetch $(cat referenced_directory_artifacts | head -n 1) | sha256sum | tr -d "[:space:]-")
-              if [ "${directory_shasum}" == "${directory_digest}" ]; then
+              if [ "sha256:${directory_shasum}" == "${directory_digest}" ]; then
                 echo "Directory blob digests match"
               else
-                echo "ERROR: Directory blob digest does not match returned value"
+                echo "ERROR: Directory blob digest sha256:${directory_shasum} does not match returned value ${directory_digest}"
                 TESTS_FAILED="true"
                 failure_num=$((failure_num + 1))
               fi
 
               ## Ensure that directory content matches
-              oras pull ${REPO}@sha256:${directory_digest}
+              oras pull ${REPO}@${directory_digest}
               diff discoveries discoveries-reference > dir_diff.txt
               if [ $? -eq 0 ]; then
                 echo "Fetched directory matches"

--- a/hack/attach.sh
+++ b/hack/attach.sh
@@ -115,7 +115,7 @@ if [ -n "${distribution_spec}" ]; then
     use_distribution_spec+=(--distribution-spec ${distribution_spec})
 fi
 oras attach "${oras_opts[@]}" --no-tty --registry-config <(select-oci-auth ${subject}) --artifact-type "${artifact_type}" \
-    "${use_distribution_spec[@]}" "${subject}" "${file_name}:${media_type}" | tail -n 1 | cut -d: -f3 > "${digest_file}"
+    "${use_distribution_spec[@]}" "${subject}" "${file_name}:${media_type}" --format go-template --template '{{.digest}}' > "${digest_file}"
 popd > /dev/null
 
 echo 'Artifacts attached'


### PR DESCRIPTION
The original method of extracting the digest resulted in a newline being appended to the digestfile. Use the suggested approach from the previous review to prevent a newline from being created.