### PR TITLE
Enable hermetic builds

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -115,7 +115,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:f8b47e7205f836bd6fe5920d6c414a7d9a7a18939d167f1c3f5534902f51fd15
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:a6299007879d8356a390ec1d99a2e5988d4eb2376c03472f99c55c369a13e749
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -382,11 +382,11 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: '{"packages": [{"path": "oras", "type": "gomod"}], "flags": ["gomod-vendor"]}'
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string


### PR DESCRIPTION
I noticed this when trying to reproduce https://issues.redhat.com/browse/KONFLUX-6229.

There, I am trying to prove that a multiarch hermetic build fails with the new ICM injection step. I expected the oras build here to fail, but it did not. Surprise! It's not a hermetic build!