### PR TITLE
Add mediaType to annotations

### DIFF
--- a/.tekton/test.yaml
+++ b/.tekton/test.yaml
@@ -130,21 +130,21 @@ spec:
               oras discover -v --format tree --artifact-type "application/vnd.konflux-ci.attached-artifact" $REPO:$TAG > discoveries/default_attached
               oras discover -v --format tree --artifact-type "application/vnd.konflux-ci.test-artifact" $REPO:$TAG > discoveries/custom_attached
 
-              if [[ "$(cat discoveries/all_attached | wc -l)" == "7" ]]; then
+              if [[ "$(cat discoveries/all_attached | wc -l)" == "9" ]]; then
                 echo "Two artifacts attached"
               else
                 echo "ERROR: All attached artifacts not found"
                 TESTS_FAILED="true"
                 failure_num=$((failure_num + 1))
               fi
-              if [[ "$(cat discoveries/default_attached | wc -l)" == "4" ]]; then
+              if [[ "$(cat discoveries/default_attached | wc -l)" == "5" ]]; then
                 echo "One artifact attached with type application/vnd.konflux-ci.attached-artifact"
               else
                 echo "ERROR: Artifact attachment application/vnd.konflux-ci.attached-artifact not found"
                 TESTS_FAILED="true"
                 failure_num=$((failure_num + 1))
               fi
-              if [[ "$(cat discoveries/custom_attached | wc -l)" == "4" ]]; then
+              if [[ "$(cat discoveries/custom_attached | wc -l)" == "5" ]]; then
                 echo "One artifact attached with type application/vnd.konflux-ci.test-artifact"
               else
                 echo "ERROR: Artifact attachment application/vnd.konflux-ci.test-artifact not found"

--- a/hack/attach.sh
+++ b/hack/attach.sh
@@ -115,7 +115,8 @@ if [ -n "${distribution_spec}" ]; then
     use_distribution_spec+=(--distribution-spec ${distribution_spec})
 fi
 oras attach "${oras_opts[@]}" --no-tty --registry-config <(select-oci-auth ${subject}) --artifact-type "${artifact_type}" \
-    "${use_distribution_spec[@]}" "${subject}" "${file_name}:${media_type}" --format go-template --template '{{.digest}}' > "${digest_file}"
+    "${use_distribution_spec[@]}" "${subject}" "${file_name}:${media_type}" --format go-template --template '{{.digest}}' \
+    --annotation "attachedMediaType=${media_type}"> "${digest_file}"
 popd > /dev/null
 
 echo 'Artifacts attached'


### PR DESCRIPTION
`oras discover` can be used to filter based on the `artifactType` but it cannot be used to filter on `mediaType`. In order to enable simpler identification of the digest based on the `mediaType`, we can add it as an attestation. This will be exposed with `oras discover --format json`.