### PR TITLE
Treat empty auth as valid in select-oci-auth script

### DIFF
--- a/hack/select-oci-auth.sh
+++ b/hack/select-oci-auth.sh
@@ -47,4 +47,3 @@ fi
 >&2 echo "Token not found for $original_ref"
 
 echo -n '{"auths": {}}'
-exit 1


### PR DESCRIPTION
Auth may be optional when using a built-in OCI registry, for example.