### PR TITLE
Change WORKDIR to /workspace

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -50,7 +50,7 @@ COPY hack/oras-options.sh /usr/local/bin/oras-options
 COPY hack/select-oci-auth.sh /usr/local/bin/select-oci-auth
 COPY --from=buildah-task-image /usr/bin/retry /usr/local/bin/
 
-WORKDIR /home/oras
+WORKDIR /workspace
 USER 65532:65532
 
 LABEL name="oras" \


### PR DESCRIPTION
The upstream oras image is using the /workspace directory as the default working directory[1].
This is not the case in the Konflux rebuild where /home/oras is used instead.

This can result in user confusion if they follow upstream oras docs where commands assuming the usage of /workspace directory are used.

[1]: https://oras.land/docs/installation/#docker-image

## Summary by Sourcery

Enhancements:
- Set WORKDIR in Containerfile to /workspace to align with upstream ORAS image