### PR TITLE
Give permissions to oras user for /workspace

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -50,6 +50,7 @@ COPY hack/oras-options.sh /usr/local/bin/oras-options
 COPY hack/select-oci-auth.sh /usr/local/bin/select-oci-auth
 COPY --from=buildah-task-image /usr/bin/retry /usr/local/bin/
 
+RUN mkdir /workspace && chown oras:oras /workspace
 WORKDIR /workspace
 USER 65532:65532
 


### PR DESCRIPTION
`oras` user does not have permissions to write in `/workspace`. Create the directory and change owner to `oras` user.

## Summary by Sourcery

Bug Fixes:
- Ensure the oras user has permission to write to /workspace by creating the directory and changing its owner