### PR TITLE
fix: remove pull_request_review from dispatch-review condition

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -93,8 +93,7 @@ jobs:
         github.event.comment.body == '/review' ||
         startsWith(github.event.comment.body, '/review ')
       )) ||
-      github.event_name == 'pull_request_target' ||
-      github.event_name == 'pull_request_review'
+      github.event_name == 'pull_request_target'
     steps:
       - name: Dispatch review
         env:


### PR DESCRIPTION
## Summary

- Removes `pull_request_review` from the `dispatch-review` job's `if` condition
- Keeps the `pull_request_review` `on:` trigger for a future fix agent

## Problem

Review bot feedback loop: each bot review triggers another dispatch-review, causing infinite re-reviews on the same SHA. See fullsend-ai/fullsend#379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Stop infinite re-review cycles by excluding pull_request_review events from the dispatch-review job condition.