### PR TITLE
fix: restrict fullsend shim to manual triage only

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -13,13 +13,11 @@ name: fullsend
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:
@@ -28,14 +26,7 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'issues' && (
-        github.event.action == 'opened' ||
-        (github.event.action == 'edited' &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'ready-to-code') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'duplicate'))
-      )) ||
-      (github.event_name == 'issue_comment' && (
+      github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         (
@@ -44,7 +35,7 @@ jobs:
           !endsWith(github.event.comment.user.login, '[bot]') &&
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info')
         )
-      ))
+      )
     steps:
       - name: Dispatch triage
         env:


### PR DESCRIPTION
## Summary

- Restricts triage dispatch to manual `/triage` commands and `needs-info` replies only
- Removes auto-triage on issue open/edit that caused infinite review agent loops
- Removes unused `pull_request_review` trigger

Propagates the fix from https://github.com/fullsend-ai/fullsend/pull/388.

## Summary by Sourcery

Restrict the Fullsend triage workflow to run only on manual triage comments and remove unused triggers.

CI:
- Limit the triage workflow to issue comments (manual /triage commands or needs-info replies) instead of reacting to issue opened/edited events.
- Remove the unused pull_request_review trigger from the Fullsend GitHub Actions workflow.